### PR TITLE
Fix Error on PHP 8.0

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -8,7 +8,7 @@ projects:
       - src: jojoe77777/FormAPI/libFormAPI
         version: ^1.3.0
         branch: master
-      - src: JackMD/UpdateNotifier/UpdateNotifier
+      - src: ifera-mc/UpdateNotifier/UpdateNotifier
         version: ^1.0.0
         branch: master
       - src: muqsit/invmenu/InvMenu

--- a/src/AndreasHGK/EasyKits/utils/LangUtils.php
+++ b/src/AndreasHGK/EasyKits/utils/LangUtils.php
@@ -39,7 +39,7 @@ abstract class LangUtils {
 
     public static function replaceVariables(string $text, array $variables) : string {
         foreach($variables as $variable => $replace) {
-            $text = str_replace($variable, $replace, $text);
+            $text = str_replace($variable, (string)$replace, $text);
         }
         return $text;
     }


### PR DESCRIPTION
"str_replace(): Argument `#2` ($replace) must be of type array|string, float given"